### PR TITLE
feat(flags): Make the struct separator configurable

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -34,6 +34,12 @@ type FlagLoader struct {
 	// "--access-key"
 	CamelCase bool
 
+	// StructSeparator is the separator for struct names in the flag. By
+	// default "-" is used. For example a config entry of
+	// Struct1.Struct2.Option will result in a flag of
+	//"--struct1-struct2-option"
+	StructSeparator string
+
 	// EnvPrefix is just a placeholder to print the correct usages when an
 	// EnvLoader is used
 	EnvPrefix string
@@ -109,6 +115,12 @@ func filterArgs(args []string) []string {
 // nested struct is detected, a flag for each field of that nested struct is
 // generated too.
 func (f *FlagLoader) processField(fieldName string, field *structs.Field) error {
+	var sep string
+	if f.StructSeparator == "" {
+		sep = "-"
+	} else {
+		sep = f.StructSeparator
+	}
 	if f.CamelCase {
 		fieldName = strings.Join(camelcase.Split(fieldName), "-")
 		fieldName = strings.Replace(fieldName, "---", "-", -1)
@@ -117,7 +129,7 @@ func (f *FlagLoader) processField(fieldName string, field *structs.Field) error 
 	switch field.Kind() {
 	case reflect.Struct:
 		for _, ff := range field.Fields() {
-			flagName := fieldName + "-" + ff.Name()
+			flagName := fieldName + sep + ff.Name()
 
 			if f.Flatten {
 				// first check if it's set or not, because if we have duplicate
@@ -140,7 +152,7 @@ func (f *FlagLoader) processField(fieldName string, field *structs.Field) error 
 	default:
 		// Add custom prefix to the flag if it's set
 		if f.Prefix != "" {
-			fieldName = f.Prefix + "-" + fieldName
+			fieldName = f.Prefix + sep + fieldName
 		}
 
 		// we only can get the value from expored fields, unexported fields panics

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fatih/structs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlag(t *testing.T) {
@@ -56,6 +57,24 @@ func TestNestedFlags(t *testing.T) {
 	if err := m.Load(s); err != nil {
 		t.Error(err)
 	}
+
+	testNestedStruct(t, s, getDefaultNestedServer())
+}
+
+func TestStructSeparatorFlags(t *testing.T) {
+	m := FlagLoader{StructSeparator: "."}
+	s := &NestedServer{}
+
+	m.Args = []string{
+		"--name", "koding",
+		"--database.postgres.enabled",
+		"--database.postgres.port", "5432",
+		"--database.postgres.hosts", "192.168.2.1,192.168.2.2,192.168.2.3",
+		"--database.postgres.dbname", "configdb",
+		"--database.postgres.availabilityratio", "8.23",
+	}
+
+	require.NoError(t, m.Load(s))
 
 	testNestedStruct(t, s, getDefaultNestedServer())
 }


### PR DESCRIPTION
The main purpose is to support `.` as a separator in a backwards compatible way.
Together with the already existing `CamelCase` option leads to much more readable flags than the current default config.