### PR TITLE
feat: Add an InterfaceLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Multiconfig is able to read configuration automatically based on the given struc
 * YAML file
 * Environment variables
 * Flags
+* Interface method
 
 
 ## Install

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,96 @@
+package multiconfig
+
+import (
+	"errors"
+	"reflect"
+)
+
+// InterfaceLoader satisfies the loader interface. It recursively checks if a
+// struct implements the DefaultValues interface and applies the function
+// depth first, if it does
+// This is useful in case you want to overwrite default values set by tags
+// in a nested struct
+type InterfaceLoader struct {
+}
+
+type DefaultValues interface {
+	ApplyDefaults()
+}
+
+// structFields returns the exported fields of a struct value or pointer
+// returns nil if the input is not a struct
+func structFields(v reflect.Value) []reflect.Value {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	t := v.Type()
+
+	fields := []reflect.Value{}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// Saves us a bunch of checks later
+		if !field.IsExported() {
+			continue
+		}
+		fv := v.FieldByName(field.Name)
+		fields = append(fields, fv)
+	}
+
+	return fields
+}
+
+// Load will populate s by recursively calling the `ApplyDefaults` method on it
+func (l *InterfaceLoader) Load(s interface{}) error {
+	v := reflect.ValueOf(s)
+	if v.Kind() != reflect.Pointer {
+		return errors.New("cannot load into a value: target must be a pointer")
+	}
+	if v.IsNil() {
+		return errors.New("cannot load into a nil pointer")
+	}
+	l.processValue(v)
+	return nil
+}
+
+// processValue is the actual implementation of Load
+// It was split out so that the signature is more amenable for the recursion that it does
+func (l *InterfaceLoader) processValue(v reflect.Value) {
+	for _, field := range structFields(v) {
+		switch field.Kind() {
+		case reflect.Struct:
+			l.processValue(field)
+		case reflect.Pointer:
+			if field.IsNil() {
+				field.Set(reflect.New(field.Type().Elem()))
+			}
+			if field.Elem().Kind() == reflect.Struct {
+				l.processValue(field)
+			} else {
+				if applyDefaults := field.MethodByName("ApplyDefaults"); applyDefaults.IsValid() {
+					applyDefaults.Call([]reflect.Value{})
+				}
+			}
+		default:
+			if field.CanAddr() {
+				if applyDefaults := field.Addr().MethodByName("ApplyDefaults"); applyDefaults.IsValid() {
+					applyDefaults.Call([]reflect.Value{})
+				}
+			}
+		}
+	}
+
+	if v.Kind() == reflect.Pointer {
+		if applyDefaults := v.MethodByName("ApplyDefaults"); applyDefaults.IsValid() {
+			applyDefaults.Call([]reflect.Value{})
+		}
+	} else {
+		if applyDefaults := v.Addr().MethodByName("ApplyDefaults"); applyDefaults.IsValid() {
+			applyDefaults.Call([]reflect.Value{})
+		}
+	}
+}

--- a/interface_example_test.go
+++ b/interface_example_test.go
@@ -1,0 +1,46 @@
+package multiconfig_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/exoscale/multiconfig"
+)
+
+// Config is an example application config
+type Config struct {
+	MyFlag bool
+	Mode   string `default:"fast"`
+	ServerConfig
+}
+
+// ServerConfig is generic server configuration that
+// supplies a default for the Port
+type ServerConfig struct {
+	Endpoint string `default:"localhost"`
+	Port     uint   `default:"8080"`
+}
+
+// ApplyDefaults overwrites the default port supplied
+// by the embedded ServerConfig
+func (c *Config) ApplyDefaults() {
+	c.ServerConfig.Port = 9090
+}
+
+func ExampleInterfaceLoader() {
+	// We apply the defaults supplied by tags before we apply the defaults supplied by the interface
+	loader := multiconfig.MultiLoader(&multiconfig.TagLoader{}, &multiconfig.InterfaceLoader{})
+	conf := &Config{}
+
+	if err := loader.Load(conf); err != nil {
+		fmt.Println("Failed to load config: ", err)
+	}
+	output, err := json.Marshal(conf)
+	if err != nil {
+		fmt.Println("Failed to marshal configuration: ", err)
+	}
+	fmt.Printf("%s\n", output)
+
+	// Output:
+	// {"MyFlag":false,"Mode":"fast","Endpoint":"localhost","Port":9090}
+}

--- a/interface_test.go
+++ b/interface_test.go
@@ -1,0 +1,162 @@
+package multiconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterfaceLoader(t *testing.T) {
+	t.Run("Should be a noop if nothing implements the interface", func(t *testing.T) {
+		loader := InterfaceLoader{}
+		conf := &TestConfig{}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, &TestConfig{}, conf)
+	})
+
+	t.Run("Should invoke ApplyDefaults if top struct implements interface", func(t *testing.T) {
+		loader := InterfaceLoader{}
+		conf := &Config1{}
+		expected := &Config1{
+			Input:  "default string",
+			Result: 42,
+			Flag:   true,
+		}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, expected, conf)
+	})
+
+	t.Run("Should return an error when trying to load into a non-pointer", func(t *testing.T) {
+		loader := InterfaceLoader{}
+		conf := Config1{}
+
+		require.EqualError(t, loader.Load(conf), "cannot load into a value: target must be a pointer")
+	})
+
+	t.Run("Should return an error if the input is nil", func(t *testing.T) {
+		loader := InterfaceLoader{}
+		var conf *Config1
+
+		require.EqualError(t, loader.Load(conf), "cannot load into a nil pointer")
+	})
+
+	t.Run("Should invoke ApplyDefaults on nested struct", func(t *testing.T) {
+		type NestedConfig struct {
+			Output string
+			Config1
+		}
+		loader := &InterfaceLoader{}
+		conf := &NestedConfig{}
+		expected := &NestedConfig{
+			Output: "",
+			Config1: Config1{
+				Input:  "default string",
+				Result: 42,
+				Flag:   true,
+			},
+		}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, expected, conf)
+	})
+
+	t.Run("Should invoke ApplyDefaults on nested struct-pointer", func(t *testing.T) {
+		type NestedConfig struct {
+			Output  string
+			Config1 *Config1
+		}
+		loader := &InterfaceLoader{}
+		conf := &NestedConfig{}
+		expected := &NestedConfig{
+			Output: "",
+			Config1: &Config1{
+				Input:  "default string",
+				Result: 42,
+				Flag:   true,
+			},
+		}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, expected, conf)
+	})
+
+	t.Run("Should invoke ApplyDefaults recursively depth first", func(t *testing.T) {
+		loader := &InterfaceLoader{}
+		conf := &Config2{}
+		expected := &Config2{
+			Output: "my output",
+			Config1: Config1{
+				Input:  "my input",
+				Result: 42,
+				Flag:   true,
+			},
+		}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, expected, conf)
+	})
+
+	// Not sure why anyone would do this, but someone will try so let's try to support it anyway
+	t.Run("Should work when ApplyDefaults is implemented on a non-struct type", func(t *testing.T) {
+		loader := &InterfaceLoader{}
+		conf := new(IntWithDefault)
+		expected := IntWithDefault(42)
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, &expected, conf)
+	})
+
+	t.Run("Should work when ApplyDefaults is implemented on a nested non-struct type", func(t *testing.T) {
+		loader := &InterfaceLoader{}
+		conf := &Config3{}
+		expected := &Config3{
+			Config1: Config1{
+				Input:  "default string",
+				Result: 42,
+				Flag:   true,
+			},
+			IntWithDefault: 42,
+		}
+
+		require.NoError(t, loader.Load(conf))
+		require.Equal(t, expected, conf)
+	})
+}
+
+type TestConfig struct {
+	pField string //nolint:unused
+	Input  string
+	Result int
+	Flag   bool
+}
+
+type Config1 TestConfig
+
+func (c *Config1) ApplyDefaults() {
+	c.Input = "default string"
+	c.Result = 42
+	c.Flag = true
+}
+
+type Config2 struct {
+	Output string
+	Config1
+}
+
+func (c *Config2) ApplyDefaults() {
+	c.Output = "my output"
+	c.Config1.Input = "my input"
+}
+
+type IntWithDefault int
+
+func (i *IntWithDefault) ApplyDefaults() {
+	*i = IntWithDefault(42)
+}
+
+type Config3 struct {
+	Config1
+	IntWithDefault
+}


### PR DESCRIPTION
The interface loader will call `ApplyDefaults` on the struct, if implemented.
This method can mutate the struct to set values.

Its intended use is to overwrite default values set by tags in embedded structs.

See the included example for usage.