### PR TITLE
feat: Support map types in flag, tag and env loaders

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -219,6 +219,7 @@ func TestFlagValueSupport(t *testing.T) {
 		t.Fatalf("got %q, want %q", e.Public, m.Args[3])
 	}
 }
+
 func TestCustomUsageTag(t *testing.T) {
 	const usageMsg = "foobar help"
 	strt := struct {
@@ -237,6 +238,24 @@ func TestCustomUsageTag(t *testing.T) {
 	if f.Usage != usageMsg {
 		t.Fatalf("usage message was %q, expected %q", f.Usage, usageMsg)
 	}
+}
+
+func TestMapFlagSupport(t *testing.T) {
+	m := &FlagLoader{CamelCase: true}
+
+	m.Args = []string{
+		"-map-string-int", "key1=1234,key2=456",
+		"-map-string-string", "key1=val1,key2=val2",
+	}
+
+	var e struct {
+		MapStringInt    map[string]int
+		MapStringString map[string]string
+	}
+
+	require.NoError(t, m.Load(&e))
+	require.EqualValues(t, map[string]int{"key1": 1234, "key2": 456}, e.MapStringInt)
+	require.EqualValues(t, map[string]string{"key1": "val1", "key2": "val2"}, e.MapStringString)
 }
 
 // getFlags returns a slice of arguments that can be passed to flag.Parse()

--- a/multiconfig.go
+++ b/multiconfig.go
@@ -142,120 +142,405 @@ func fieldSet(field *structs.Field, v string) error {
 	case reflect.Bool:
 		val, err := strconv.ParseBool(v)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as bool: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(val); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Int:
 		i, err := strconv.Atoi(v)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(i); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.String:
 		if err := field.Set(v); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Slice:
 		switch t := field.Value().(type) {
 		case []string:
 			if err := field.Set(strings.Split(v, ",")); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		case []int:
 			var list []int
 			for _, in := range strings.Split(v, ",") {
-				i, err := strconv.Atoi(in)
+				i, err := strconv.ParseInt(in, 10, strconv.IntSize)
 				if err != nil {
-					return err
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", in, field.Name(), err)
 				}
 
-				list = append(list, i)
+				list = append(list, int(i))
 			}
 
 			if err := field.Set(list); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int64:
+			var list []int64
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", in, field.Name(), err)
+				}
+				list = append(list, i)
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int32:
+			var list []int32
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int32: %w", in, field.Name(), err)
+				}
+				list = append(list, int32(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int16:
+			var list []int16
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int16: %w", in, field.Name(), err)
+				}
+				list = append(list, int16(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int8:
+			var list []int8
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int8: %w", in, field.Name(), err)
+				}
+				list = append(list, int8(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint:
+			var list []uint
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", in, field.Name(), err)
+				}
+				list = append(list, uint(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint64:
+			var list []uint64
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", in, field.Name(), err)
+				}
+				list = append(list, i)
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint32:
+			var list []uint32
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", in, field.Name(), err)
+				}
+				list = append(list, uint32(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint16:
+			var list []uint16
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", in, field.Name(), err)
+				}
+				list = append(list, uint16(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint8:
+			var list []uint8
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint8: %w", in, field.Name(), err)
+				}
+				list = append(list, uint8(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		default:
-			return fmt.Errorf("multiconfig: field '%s' of type slice is unsupported: %s (%T)",
+			return fmt.Errorf("field '%s' of type slice is unsupported: %s (%T)",
 				field.Name(), field.Kind(), t)
+		}
+	case reflect.Map:
+		switch field.Value().(type) {
+		case map[string]string:
+			output := map[string]string{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				output[key] = val
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int:
+			output := map[string]int{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", val, field.Name(), err)
+				}
+				output[key] = int(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int64:
+			output := map[string]int64{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", val, field.Name(), err)
+				}
+				output[key] = i
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int32:
+			output := map[string]int32{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int32: %w", val, field.Name(), err)
+				}
+				output[key] = int32(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int16:
+			output := map[string]int16{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int16: %w", val, field.Name(), err)
+				}
+				output[key] = int16(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int8:
+			output := map[string]int8{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int8: %w", val, field.Name(), err)
+				}
+				output[key] = int8(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint:
+			output := map[string]uint{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", val, field.Name(), err)
+				}
+				output[key] = uint(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint64:
+			output := map[string]uint64{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", val, field.Name(), err)
+				}
+				output[key] = i
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint32:
+			output := map[string]uint32{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", val, field.Name(), err)
+				}
+				output[key] = uint32(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint16:
+			output := map[string]uint16{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", val, field.Name(), err)
+				}
+				output[key] = uint16(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint8:
+			output := map[string]uint8{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint8: %w", val, field.Name(), err)
+				}
+				output[key] = uint8(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		default:
+			return fmt.Errorf("field '%s' of type map is unsupported: %s (%T)", field.Name(), field.Kind(), field.Value())
 		}
 	case reflect.Float64:
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as float64: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(f); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Int64:
 		switch t := field.Value().(type) {
 		case time.Duration:
 			d, err := time.ParseDuration(v)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot parse value '%s' of field '%s' as duration: %w", v, field.Name(), err)
 			}
 
 			if err := field.Set(d); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		case int64:
-			p, err := strconv.ParseInt(v, 10, 0)
+			p, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", v, field.Name(), err)
 			}
 
 			if err := field.Set(p); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		default:
-			return fmt.Errorf("multiconfig: field '%s' of type int64 is unsupported: %s (%T)",
+			return fmt.Errorf("field '%s' of type int64 is unsupported: %s (%T)",
 				field.Name(), field.Kind(), t)
 		}
 	case reflect.Uint:
-		u, err := strconv.ParseUint(v, 10, 0)
+		u, err := strconv.ParseUint(v, 10, strconv.IntSize)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint16:
 		u, err := strconv.ParseUint(v, 10, 16)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint16(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint32:
 		u, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint32(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint64:
 		u, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(u); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	default:
-		return fmt.Errorf("multiconfig: field '%s' has unsupported type: %s", field.Name(), field.Kind())
+		return fmt.Errorf("field '%s' has unsupported type: %s", field.Name(), field.Kind())
 	}
 
 	return nil

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -130,6 +130,7 @@ func TestLoad(t *testing.T) {
 
 func TestDefaultLoader(t *testing.T) {
 	m := New()
+	setEnvVars(t, "Server", "")
 
 	s := new(Server)
 	if err := m.Load(s); err != nil {


### PR DESCRIPTION
Adds support for loading configuration into map[string]string and map[string]int (and related) types.
The string encoding used is the same as the one used in pflag: elements are delimited by comma's (like for slices) and key values are split by equals sign (=). For example:
key1=val1,key2=val2

While updating the string parser, I have updated the error messages that are returned. They now leverage error wrapping and include more information about the field and value that contained the error.